### PR TITLE
C# Latest Tooling - 2.10.0 test csharp complex type remote inputs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         debug: true
+        tools: latest
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
I can repro the same scenario w/ deserialization vuln (not unsurprising as it uses the same DataFlow)
- [two instances](https://github.com/vulna-felickz/DotNetCoreWebApp/blob/f0fa6dcbf9fe089921e32b44b903d876e928f99d/DotNetCoreWebApp/Controllers/ErrorController.cs#L90-L108) (one simple / one complex)
- [one alert](https://github.com/vulna-felickz/DotNetCoreWebApp/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3Acs%2Funsafe-deserialization-untrusted-input) (simple type binding only)


<img width="956" alt="image" src="https://user-images.githubusercontent.com/1760475/176789009-b77bf239-dc82-47da-9820-00222ac960a4.png">


# Results - upgrading to 2.10.0 CLI bundle
Fixed in 2.10.0 CLI bundle and 0.2.0 codeql/csharp-queries ([changelog](https://github.com/github/codeql/blob/codeql-cli/v2.10.0/csharp/ql/src/CHANGELOG.md#020
))
>All auto implemented public properties with public getters and setters on ASP.NET Core remote flow sources are now also considered to be tainted.


Forcing Action to 2.10.0 lights up a bunch of alerts that were missing for me ( n[ew alerts on complex types](https://github.com/vulna-felickz/DotNetCoreWebApp/pull/4/checks?check_run_id=7140710486))

>6 new alerts including 6 critical severity security vulnerabilities
New alerts
Security Alerts:
>
>6 critical
See annotations below for details.
>
>[View all branch alerts](https://github.com/vulna-felickz/DotNetCoreWebApp/security/code-scanning?query=pr%3A4+tool%3ACodeQL+is%3Aopen).