### PR TITLE
hangfire.core includes transitive with vuln

### DIFF
--- a/DotNetCoreWebApp/DotNetCoreWebApp.csproj
+++ b/DotNetCoreWebApp/DotNetCoreWebApp.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.31" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/DotNetCoreWebApp/packages.lock.json
+++ b/DotNetCoreWebApp/packages.lock.json
@@ -20,6 +20,15 @@
         "resolved": "11.1.0",
         "contentHash": "Ld7w+2jOmnhQqFkngEGuEWTRa5j6u4Xzli7jKxRtbA5PtuHHcpin01qxvxYL0LomeJuzRMGAOURu2rKONdjKQA=="
       },
+      "Hangfire.Core": {
+        "type": "Direct",
+        "requested": "[1.7.31, )",
+        "resolved": "1.7.31",
+        "contentHash": "2SthlIUr2NgFMPQteHZ8SRWj9A8MT0fDcT8D2gSZdVlvb+kvj+250hXOJMm2z/eQoCa0pJ0qFyy8Npxa/JfFiA==",
+        "dependencies": {
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.2, )",
@@ -44,6 +53,11 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "11.0.1",
+        "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",


### PR DESCRIPTION
dotnet add package Hangfire.Core --version 1.7.31
- https://www.nuget.org/packages/Hangfire.Core/
   - Depends on Newtonsoft.JSON 11.0.1 which has an advisory [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)

Showing green - not detecting vuln on transitives
![image](https://user-images.githubusercontent.com/1760475/198414392-f9a2ef73-3560-45aa-9c21-a571c3eeffc6.png)
